### PR TITLE
Changed indexes when referencing insertedIds in Mutations

### DIFF
--- a/src/start.js
+++ b/src/start.js
@@ -78,11 +78,11 @@ export const start = async () => {
       Mutation: {
         createPost: async (root, args, context, info) => {
           const res = await Posts.insert(args)
-          return prepare(await Posts.findOne({_id: res.insertedIds[1]}))
+          return prepare(await Posts.findOne({_id: res.insertedIds[0]}))
         },
         createComment: async (root, args) => {
           const res = await Comments.insert(args)
-          return prepare(await Comments.findOne({_id: res.insertedIds[1]}))
+          return prepare(await Comments.findOne({_id: res.insertedIds[0]}))
         },
       },
     }


### PR DESCRIPTION
I love the tutorial, but was confused why the example mutation query wasn't running off-the-bat.

This error was popping  up:

```
TypeError: Cannot read property '_id' of null
```

A console log of the query in the resolver showed that the id was the only item in the array `insertedIds` array.  Changing the index to the first item fixed it.  Maybe related to the version of MongoDB released at the time the tutorial was published.